### PR TITLE
Change in datatype of lun_id

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -332,7 +332,8 @@ PUT `/containers/v1/volumes/{id}/actions/publish`
     "discovery_ips": [
         "172.89.82.10"
     ],
-    "lun_id": [0,1],
+    "lun_id": 3,
+    "peer_lun_ids": [4],
     "serial_number": "4349bd228896f1236c9ce9006592f26f",
     "target_names": ["iqn.2007-11.com.nimblestorage:group-array1-g3b5de80e54af7a6b"]
 }
@@ -347,7 +348,8 @@ PUT `/containers/v1/volumes/{id}/actions/publish`
     "discovery_ips": [
         "172.89.82.10"
     ],
-    "lun_id": [0,1],
+    "lun_id": 3,
+    "peer_lun_ids": [4],
     "serial_number": "4349bd228896f1236c9ce9006592f26f",
     "target_names": ["iqn.2000-05.com.3pardata:21210002ac01db31,iqn.2000-05.com.3pardata:21220002ac01db31"]
 }
@@ -365,7 +367,8 @@ PUT `/containers/v1/volumes/{id}/actions/publish`
 ```json
 {
     "access_protocol": "fc",
-    "lun_id": [0,1],
+    "lun_id": 0,
+    "peer_lun_ids": [4],
     "serial_number": "4349bd228896f1236c9ce9006592f26f"
 }
 ```
@@ -918,7 +921,8 @@ DELETE http://localhost:8080/csp/containers/v1/snapshot_groups/052265c9672660666
 | PublishInfo | | | | | |
 | | serial_number | string | X | | X |
 | | access_protocol | string | X | | X |
-| | lun_id | list\<number\> | X | | X |
+| | lun_id | number | X | | X |
+| | peer_lun_ids | list\<number\> | X | | X|
 | | target_names | list\<string\> | only for iscsi | | X |
 | | discovery_ips | list\<string\> | only for iscsi | | X |
 | | chap_user | string | only for iscsi | | X |

--- a/spec.md
+++ b/spec.md
@@ -333,7 +333,7 @@ PUT `/containers/v1/volumes/{id}/actions/publish`
         "172.89.82.10"
     ],
     "lun_id": 3,
-    "peer_lun_ids": [4],
+    "PeerArrayDetails": [{"lun_id":1,"target_names":["iqn.2000-05.com.3pardata:20210002ac01db2c","iqn.2000-05.com.3pardata:21210002ac01db2c"],"discovery_ips":["1.1.1.1","2.2.2.2"]}],
     "serial_number": "4349bd228896f1236c9ce9006592f26f",
     "target_names": ["iqn.2007-11.com.nimblestorage:group-array1-g3b5de80e54af7a6b"]
 }
@@ -349,7 +349,7 @@ PUT `/containers/v1/volumes/{id}/actions/publish`
         "172.89.82.10"
     ],
     "lun_id": 3,
-    "peer_lun_ids": [4],
+    "PeerArrayDetails": [{"lun_id":1,"target_names":["iqn.2000-05.com.3pardata:20210002ac01db2c","iqn.2000-05.com.3pardata:21210002ac01db2c"],"discovery_ips":["1.1.1.1","2.2.2.2"]}],
     "serial_number": "4349bd228896f1236c9ce9006592f26f",
     "target_names": ["iqn.2000-05.com.3pardata:21210002ac01db31,iqn.2000-05.com.3pardata:21220002ac01db31"]
 }
@@ -368,7 +368,7 @@ PUT `/containers/v1/volumes/{id}/actions/publish`
 {
     "access_protocol": "fc",
     "lun_id": 0,
-    "peer_lun_ids": [4],
+    "PeerArrayDetails": [{"lun_id":1}],
     "serial_number": "4349bd228896f1236c9ce9006592f26f"
 }
 ```
@@ -922,11 +922,15 @@ DELETE http://localhost:8080/csp/containers/v1/snapshot_groups/052265c9672660666
 | | serial_number | string | X | | X |
 | | access_protocol | string | X | | X |
 | | lun_id | number | X | | X |
-| | peer_lun_ids | list\<number\> | X | | X|
+| | PeerArrayDetails | list\<SecondaryLunInfo\> | X | | X|
 | | target_names | list\<string\> | only for iscsi | | X |
 | | discovery_ips | list\<string\> | only for iscsi | | X |
 | | chap_user | string | only for iscsi | | X |
 | | chap_password | string | only for iscsi | | X |
+|  SecondaryLunInfo | | | | | |
+| | lun_id | number | X | X |
+| | target_names | list\<string\> | only for iscsi | | X |
+| | discovery_ips | list\<string\> | only for iscsi | | X |
 | UnpublishOptions | | | | | |
 | | host_uuid | string | X | X | |
 | Snapshot | | | | | |

--- a/spec.md
+++ b/spec.md
@@ -332,7 +332,7 @@ PUT `/containers/v1/volumes/{id}/actions/publish`
     "discovery_ips": [
         "172.89.82.10"
     ],
-    "lun_id": 0,
+    "lun_id": [0,1],
     "serial_number": "4349bd228896f1236c9ce9006592f26f",
     "target_names": ["iqn.2007-11.com.nimblestorage:group-array1-g3b5de80e54af7a6b"]
 }
@@ -347,7 +347,7 @@ PUT `/containers/v1/volumes/{id}/actions/publish`
     "discovery_ips": [
         "172.89.82.10"
     ],
-    "lun_id": 0,
+    "lun_id": [0,1],
     "serial_number": "4349bd228896f1236c9ce9006592f26f",
     "target_names": ["iqn.2000-05.com.3pardata:21210002ac01db31,iqn.2000-05.com.3pardata:21220002ac01db31"]
 }
@@ -365,7 +365,7 @@ PUT `/containers/v1/volumes/{id}/actions/publish`
 ```json
 {
     "access_protocol": "fc",
-    "lun_id": 0,
+    "lun_id": [0,1],
     "serial_number": "4349bd228896f1236c9ce9006592f26f"
 }
 ```
@@ -918,7 +918,7 @@ DELETE http://localhost:8080/csp/containers/v1/snapshot_groups/052265c9672660666
 | PublishInfo | | | | | |
 | | serial_number | string | X | | X |
 | | access_protocol | string | X | | X |
-| | lun_id | number | X | | X |
+| | lun_id | list\<number\> | X | | X |
 | | target_names | list\<string\> | only for iscsi | | X |
 | | discovery_ips | list\<string\> | only for iscsi | | X |
 | | chap_user | string | only for iscsi | | X |


### PR DESCRIPTION
Based on further review comments by Shiva,

- We will not change the datatype of lun_id 
- Instead we will introduce the `peer_lun_ids` which will contains the lun_id from the secondary array.
- model.Volume will have this new field , and the rescan/remap of lun_id will be done secondary array if they are present.

```
time="2020-06-30T17:32:22Z" level=info msg="[ REQUEST-ID 100092 ] -- Response returned successfully for publish volume &models.PublishVolumeResponse{AccessProtocol:\"iscsi\", DiscoveryIPs:[]string{\"192.168.68.203\", \"192.168.68.228\", \"192.168.68.201\", \"192.168.68.229\", \"192.168.68.206\", \"192.168.68.202\"}, LunID:2, PeerLunIDs:[]int32{23}, SerialNumber:\"60002ac0000000000101997a0001db31\", TargetNames:[]string{\"iqn.2000-05.com.3pardata:20210002ac01db31\", \"iqn.2000-05.com.3pardata:20220002ac01db31\", \"iqn.2000-05.com.3pardata:21210002ac01db31\", \"iqn.2000-05.com.3pardata:21220002ac01db31\", \"iqn.2000-05.com.3pardata:20210002ac01db2c\", \"iqn.2000-05.com.3pardata:21210002ac01db2c\"}, ChapUser:\"\", ChapPassword:\"\"}" file="publish_volume_cmd.go:440"
```

Required for PR -- https://github.com/hpe-storage/common-host-libs/pull/126/files
Signed-off-by: William Durairaj <w_durairaj@yahoo.com>