### PR TITLE
Add virtual_domain (and nqns, access_protocol) to CSP Host schema

### DIFF
--- a/nimble-storage/nimble-csp-api-openapi.json
+++ b/nimble-storage/nimble-csp-api-openapi.json
@@ -1296,6 +1296,12 @@
               "type": "string"
             }
           },
+          "nqns": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
           "networks": {
             "type": "array",
             "items": {
@@ -1307,6 +1313,14 @@
           },
           "chap_password": {
             "type": "string"
+          },
+          "access_protocol": {
+            "type": "string",
+            "description": "Data access protocol the host uses to attach volumes (for example: iscsi, fc, nvme)."
+          },
+          "virtual_domain": {
+            "type": "string",
+            "description": "Optional virtual domain that the host belongs to. When set, the CSP scopes host and volume export operations to this virtual domain."
           }
         }
       },

--- a/nimble-storage/nimble-csp-api-openapi.yaml
+++ b/nimble-storage/nimble-csp-api-openapi.yaml
@@ -833,6 +833,10 @@ components:
           type: array
           items:
             type: string
+        nqns:
+          type: array
+          items:
+            type: string
         networks:
           type: array
           items:
@@ -841,6 +845,12 @@ components:
           type: string
         chap_password:
           type: string
+        access_protocol:
+          type: string
+          description: 'Data access protocol the host uses to attach volumes (for example: iscsi, fc, nvme).'
+        virtual_domain:
+          type: string
+          description: Optional virtual domain that the host belongs to. When set, the CSP scopes host and volume export operations to this virtual domain.
     PublishInfo:
       type: object
       properties:

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -848,6 +848,10 @@ components:
           type: array
           items:
             type: string
+        nqns:
+          type: array
+          items:
+            type: string
         networks:
           type: array
           items:
@@ -856,6 +860,16 @@ components:
           type: string
         chap_password:
           type: string
+        access_protocol:
+          type: string
+          description: >-
+            Data access protocol the host uses to attach volumes
+            (for example: iscsi, fc, nvme).
+        virtual_domain:
+          type: string
+          description: >-
+            Optional virtual domain that the host belongs to. When set, the CSP
+            scopes host and volume export operations to this virtual domain.
     PublishInfo:
       type: object
       properties:

--- a/spec.md
+++ b/spec.md
@@ -46,7 +46,7 @@ This endpoint is used to register hosts with the CSP.
 
 POST `/containers/v1/hosts`
  * Registers a host with the CSP
- * The body must contain a host UUID, name, initiators (either IQNs, WWPNs or both), networks (if using iSCSI), and optional CHAP information (for iSCSI)
+ * The body must contain a host UUID, name, initiators (IQNs, WWPNs and/or NQNs), networks (if using iSCSI), optional CHAP information (for iSCSI), and an optional virtual domain
  * The response will report a new Host.  The ID returned from this POST request be used to publish and unpublish a volume
 
 #### Request
@@ -934,9 +934,12 @@ GET http://localhost:8080/csp/containers/v1/replication_partners
 | | name | string | X | X | X |
 | | iqns | list\<string\> | when wwpns are not specified | X | X |
 | | wwpns | list\<string\> | when iqns are not specified | X | X |
+| | nqns | list\<string\> | when using NVMe-oF | X | X |
 | | networks | list\<string\> | when iqns are specified | X | X |
 | | chap_user | string |  | X | X |
 | | chap_password | string | | X | X |
+| | access_protocol | string | | X | X |
+| | virtual_domain | string | | X | X |
 | Volume | | | | | |
 | | id | string | | | X |
 | | name | string | X | X | X |


### PR DESCRIPTION
Add the virtual_domain field in the OpenAPI Host schema for Node and reconcile it with other missing fields like nqns and access_protocol. Regenerate nimble-storage/*-openapi.{yaml,json} and document the fields in spec.md.